### PR TITLE
Upgrade gradle-node-plugin dependcy to 1.2.0

### DIFF
--- a/src/main/java/de/infonautika/postman/task/InstallNewmanTask.java
+++ b/src/main/java/de/infonautika/postman/task/InstallNewmanTask.java
@@ -1,8 +1,8 @@
 package de.infonautika.postman.task;
 
 import com.moowork.gradle.node.NodeExtension;
-import com.moowork.gradle.node.task.NpmSetupTask;
-import com.moowork.gradle.node.task.NpmTask;
+import com.moowork.gradle.node.npm.NpmSetupTask;
+import com.moowork.gradle.node.npm.NpmTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 


### PR DESCRIPTION
To fix class not found exception during installation as gradle-node-plugin has repackage NpmSetupTask & NpmTask into pkg com.moowork.gradle.node.npm after 1.x.x